### PR TITLE
[bugfix] Ensure library state change is saved

### DIFF
--- a/app/models/library_tube.rb
+++ b/app/models/library_tube.rb
@@ -38,7 +38,7 @@ class LibraryTube < Tube
 
   def specialized_from_manifest=(attributes)
     aliquots.first.update_attributes!(attributes)
-    requests.map(&:manifest_processed)
+    requests.map(&:manifest_processed!)
   end
 
   def library_information

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -519,5 +519,5 @@ class Request < ActiveRecord::Base
     false
   end
 
-  def manifest_processed; end
+  def manifest_processed!; end
 end


### PR DESCRIPTION
If we don't update library state,re-uploads of the manifest repeatedly trigger transfers, resulting in tag clashes.