### PR TITLE
Allow more overhead

### DIFF
--- a/app/models/sample_manifest.rb
+++ b/app/models/sample_manifest.rb
@@ -20,7 +20,7 @@ class SampleManifest < ActiveRecord::Base
   # to allow for:
   # 1) Subsequent serialization by the delayed job
   # 2) The addition of a 'too many errors' message
-  LIMIT_ERROR_LENGTH = 60000
+  LIMIT_ERROR_LENGTH = 50000
 
   module Associations
     def self.included(base)


### PR DESCRIPTION
We need to be more pessimistic when truncating error as more overhead is needed by the delayed job.
Really the delayed job should probably use the persisted version of the manifest, rather than a serialised copy.